### PR TITLE
filters out additional internal events from dataexport set

### DIFF
--- a/docker/run.sh
+++ b/docker/run.sh
@@ -119,7 +119,7 @@ rm "$filename".manifest
 echo "exporting event table content"
 
 PGPASSWORD=$DB_PASSWORD psql "sslmode=verify-ca sslrootcert=/root/.postgresql/root.crt sslcert=/root/.postgresql/postgresql.crt sslkey=/tmp/client-key.pem hostaddr=$DB_HOST port=$DB_PORT user=$DB_USERNAME dbname=rm" \
--c "\copy (SELECT row_to_json(t) FROM (SELECT * FROM casev2.event where event_type!='CASE_CREATED' and event_type!='UAC_UPDATED') t) To 'events.json';"
+-c "\copy (SELECT row_to_json(t) FROM (SELECT * FROM casev2.event where event_type!='CASE_CREATED' and event_type!='UAC_UPDATED' and event_type!='SAMPLE_LOADED' and event_type!='RM_UAC_CREATED' and event_type!='PRINT_CASE_SELECTED') t) To 'events.json';"
 
 
 echo "zipping event file"


### PR DESCRIPTION
Change
Updates the SQL events table query to exclude additional internal RM events. Additional events excluded are ...

PRINT_CASE_SELECTED
RM_UAC_CREATED
SAMPLE_LOADED

Motivation
This is to keep the size of the exported file down and remove information not required for MI or processing purposes.