### PR TITLE
change queries to take changes from previous day

### DIFF
--- a/docker/run.sh
+++ b/docker/run.sh
@@ -133,7 +133,7 @@ echo "exporting event table content"
 EVENTS_FILE=events_$PERIOD_DATE.json
 
 PGPASSWORD=$DB_PASSWORD psql "sslmode=verify-ca sslrootcert=/root/.postgresql/root.crt sslcert=/root/.postgresql/postgresql.crt sslkey=/tmp/client-key.pem hostaddr=$DB_HOST port=$DB_PORT user=$DB_USERNAME dbname=rm" \
--c "\copy (SELECT row_to_json(t) FROM (SELECT * FROM casev2.event where event_type!='CASE_CREATED' and event_type!='UAC_UPDATED' and event_type!='SAMPLE_LOADED' and event_type!='RM_UAC_CREATED' and event_type!='PRINT_CASE_SELECTED' and event_date >= '$START_OF_PERIOD' and event_date < '$END_OF_PERIOD') t) To '$EVENTS_FILE';"
+-c "\copy (SELECT row_to_json(t) FROM (SELECT * FROM casev2.event where event_type!='CASE_CREATED' and event_type!='UAC_UPDATED' and event_type!='SAMPLE_LOADED' and event_type!='RM_UAC_CREATED' and event_type!='PRINT_CASE_SELECTED' and rm_event_processed >= '$START_OF_PERIOD' and rm_event_processed < '$END_OF_PERIOD') t) To '$EVENTS_FILE';"
 
 
 echo "zipping event file"

--- a/docker/run.sh
+++ b/docker/run.sh
@@ -9,6 +9,11 @@ set -o nounset
 # set -o xtrace
 
 
+PERIOD_DATE=$(date -u -d@"$(( `date -u +%s`-86400))" "+%Y-%m-%d")
+START_OF_PERIOD=$(date -d@"$(( `date -u +%s`-86400))" "+%Y-%m-%d 00:00:00")
+END_OF_PERIOD=$(date -u "+%Y-%m-%d 00:00:00")
+
+
 ############################################################################
 # PREPARE POSTGRES CERTIFICATES
 # convert java pk8 required key format to pem if we're running in kubernetes
@@ -28,16 +33,15 @@ cd $PVC_MOUNT_PATH
 echo "exporting uac_qid_link table content (no UACs)"
 
 
-
-QID_FILE=qid_$(date +"%Y-%m-%dT%H-%M-%S").json
+QID_FILE=qid_$PERIOD_DATE.json
 
 PGPASSWORD=$DB_PASSWORD psql "sslmode=verify-ca sslrootcert=/root/.postgresql/root.crt sslcert=/root/.postgresql/postgresql.crt sslkey=/tmp/client-key.pem hostaddr=$DB_HOST port=$DB_PORT user=$DB_USERNAME dbname=rm" \
--c "\copy (SELECT row_to_json(t) FROM (SELECT id,qid,caze_case_ref as case_ref FROM casev2.uac_qid_link) t) To '$QID_FILE';"
+-c "\copy (SELECT row_to_json(t) FROM (SELECT id,qid,caze_case_id as case_id FROM casev2.uac_qid_link where last_updated >= '$START_OF_PERIOD' and last_updated < '$END_OF_PERIOD') t) To '$QID_FILE';"
 
 
 echo "zipping uac_qid_link file"
 
-filename=CensusResponseManagement_qid_$(date +"%Y-%m-%dT%H-%M-%S").zip
+filename=CensusResponseManagement_qid_$PERIOD_DATE.zip
 zip "$filename" "$QID_FILE"
 
 echo "adding $filename to bucket $BUCKET_NAME"
@@ -77,15 +81,15 @@ rm "$filename".manifest
 echo "exporting cases table content"
 
 
-CASES_FILE=cases_$(date +"%Y-%m-%dT%H-%M-%S").json
+CASES_FILE=cases_$PERIOD_DATE.json
 
 PGPASSWORD=$DB_PASSWORD psql "sslmode=verify-ca sslrootcert=/root/.postgresql/root.crt sslcert=/root/.postgresql/postgresql.crt sslkey=/tmp/client-key.pem hostaddr=$DB_HOST port=$DB_PORT user=$DB_USERNAME dbname=rm" \
--c "\copy (SELECT row_to_json(t) FROM (SELECT * FROM casev2.cases) t) To '$CASES_FILE';"
+-c "\copy (SELECT row_to_json(t) FROM (SELECT * FROM casev2.cases where last_updated >= '$START_OF_PERIOD' and last_updated < '$END_OF_PERIOD') t) To '$CASES_FILE';"
 
 
 echo "zipping cases file"
 
-filename=CensusResponseManagement_case_$(date +"%Y-%m-%dT%H-%M-%S").zip
+filename=CensusResponseManagement_case_$PERIOD_DATE.zip
 zip "$filename" "$CASES_FILE"
 
 echo "adding $filename to bucket $BUCKET_NAME"
@@ -126,15 +130,15 @@ rm "$filename".manifest
 echo "exporting event table content"
 
 
-EVENTS_FILE=events_$(date +"%Y-%m-%dT%H-%M-%S").json
+EVENTS_FILE=events_$PERIOD_DATE.json
 
 PGPASSWORD=$DB_PASSWORD psql "sslmode=verify-ca sslrootcert=/root/.postgresql/root.crt sslcert=/root/.postgresql/postgresql.crt sslkey=/tmp/client-key.pem hostaddr=$DB_HOST port=$DB_PORT user=$DB_USERNAME dbname=rm" \
--c "\copy (SELECT row_to_json(t) FROM (SELECT * FROM casev2.event where event_type!='CASE_CREATED' and event_type!='UAC_UPDATED' and event_type!='SAMPLE_LOADED' and event_type!='RM_UAC_CREATED' and event_type!='PRINT_CASE_SELECTED') t) To '$EVENTS_FILE';"
+-c "\copy (SELECT row_to_json(t) FROM (SELECT * FROM casev2.event where event_type!='CASE_CREATED' and event_type!='UAC_UPDATED' and event_type!='SAMPLE_LOADED' and event_type!='RM_UAC_CREATED' and event_type!='PRINT_CASE_SELECTED' and event_date >= '$START_OF_PERIOD' and event_date < '$END_OF_PERIOD') t) To '$EVENTS_FILE';"
 
 
 echo "zipping event file"
 
-filename=CensusResponseManagement_events_$(date +"%Y-%m-%dT%H-%M-%S").zip
+filename=CensusResponseManagement_events_$PERIOD_DATE.zip
 zip "$filename" "$EVENTS_FILE"
 
 echo "adding $filename to bucket $BUCKET_NAME"


### PR DESCRIPTION
Why?
The data export queries selected the full tables. This modifies the queries to select only the previous days changes.

What?
Shell variables are set to get so a query of >= previous day at 00:00 and < todays date at 00:00. This will ensure that all records that have changed in that 24 hours will be selected.
Also a variable set to give file names the correct date.

How to test?
```docker build docker/. -t eu.gcr.io/census-rm-<<your env>>/rm/census-rm-dataexporter```
```docker push eu.gcr.io/census-rm-<<your env>>/rm/census-rm-dataexporter```

Hopefully you'll have some data in your env from the previous day to running this!
In the optional folder in the kubernetes repo, modify the ```optional/dataexporter-cronjob.yml``` file so that the image is the one you've built and push, and change the cron schedule to something that will happen in the next few minutes (I used ```schedule: "*/5 * * * *"``` (every 5 mins) to test).
(You may also need to change the read replica DB config to just db-config if you don't have a read replica set up.)
Next:
```kubectl apply -f optional/dataexporter-persistentvolume.yml```
```kubectly apply -f optional/dataexporter-cronjob.yml```

Wait for the cronjob to run, you should see a pod pop up and run until complete.
Navigate to a storage bucket called ```census-rm-<<your env>>-dataexport``` and check files 6 files are created (cases table and manifest, uac_qid_link and manifest, events and manifest). Download the zip files and check the row counts match what you should expect from when the data was selected from.

Delete the cron job.

Links:
https://trello.com/c/FyZpGBx7/815-change-mi-db-export-to-send-delta-file-instead-of-entire-dump-5
