### PR TITLE
972 Enable workload ID for DataExport job

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,4 +1,7 @@
-FROM alpine:3.7
+FROM python:3.7-slim
+
+RUN pip install pipenv
+
 RUN apk add --update \
     postgresql-client \
     openssl \
@@ -19,6 +22,13 @@ RUN apk add --update \
   && pip install gsutil \
   && apk del build-deps \
   && rm -rf /var/cache/apk/*
+
+RUN echo "deb [signed-by=/usr/share/keyrings/cloud.google.gpg] https://packages.cloud.google.com/apt cloud-sdk main" | tee -a /etc/apt/sources.list.d/google-cloud-sdk.list && \
+    curl https://packages.cloud.google.com/apt/doc/apt-key.gpg | apt-key --keyring /usr/share/keyrings/cloud.google.gpg add - && \
+    apt-get update && apt-get -yq install google-cloud-sdk
+
+
 ADD run.sh run.sh
-ADD boto /root/.boto
-ENV BOTO_CONFIG /root/.boto
+#ADD boto /root/.boto
+#ENV BOTO_CONFIG /root/.boto
+

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,6 +1,4 @@
-FROM python:3.7-slim
-
-RUN pip install pipenv
+FROM google/cloud-sdk:alpine
 
 RUN apk add --update \
     postgresql-client \
@@ -22,13 +20,4 @@ RUN apk add --update \
   && pip install gsutil \
   && apk del build-deps \
   && rm -rf /var/cache/apk/*
-
-RUN echo "deb [signed-by=/usr/share/keyrings/cloud.google.gpg] https://packages.cloud.google.com/apt cloud-sdk main" | tee -a /etc/apt/sources.list.d/google-cloud-sdk.list && \
-    curl https://packages.cloud.google.com/apt/doc/apt-key.gpg | apt-key --keyring /usr/share/keyrings/cloud.google.gpg add - && \
-    apt-get update && apt-get -yq install google-cloud-sdk
-
-
 ADD run.sh run.sh
-#ADD boto /root/.boto
-#ENV BOTO_CONFIG /root/.boto
-

--- a/docker/boto
+++ b/docker/boto
@@ -1,2 +1,2 @@
 [Credentials]
-gs_service_key_file = /gcp-credentials/service-account-key.json
+gs_service_key_file = [GoogleCompute]\nservice_account = default

--- a/docker/boto
+++ b/docker/boto
@@ -1,2 +1,0 @@
-[Credentials]
-gs_service_key_file = [GoogleCompute]\nservice_account = default


### PR DESCRIPTION
# Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
We can make use of workload ID for the Data Export job.

# What has changed
<!--- What manifest changes have been made? -->
* Changed base Docker image to allow `gsutil` to run with native authentication for workload ID
* Removed now unused file

# How to test?
<!--- Describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to see how your change affects other areas of the code, etc. -->
<!--- Are there any automated tests that mean changes don't need to be manually tested? -->
* Run Terraform from other branch
* Build an image off this branch
* Deploy the k8s branch
* Trigger the job manually in the UI by clicking on the workload, then the button at the top
* Check that the job creates and copies the necessary files to the bucket

# Links
<!--- Add any links to issues (Jira, Trello, GitHub Issues) -->
<!--- Links to any documentation. -->
<!--- Links to any related PRs. -->
https://trello.com/c/k2cVazy9/972-workload-identity-update-dataexporter-5