### PR TITLE
Add ability to run a one off data exporter using provided start and e…

### DIFF
--- a/docker/run.sh
+++ b/docker/run.sh
@@ -14,7 +14,7 @@ if [ -z "$START_DATE" ]; then
   START_OF_PERIOD=$(date -d@"$(( `date -u +%s`-86400))" "+%Y-%m-%d 00:00:00")
 else
   START_OF_PERIOD="$START_DATE 00:00:00"
-  PERIOD_DATE="${START_DATE}_initial_export"
+  PERIOD_DATE="${START_DATE}_to_${END_DATE}_initial_export"
 fi
 
 if [ -z "$END_DATE" ]; then

--- a/docker/run.sh
+++ b/docker/run.sh
@@ -8,11 +8,20 @@ set -o nounset
 # uncomment for trace
 # set -o xtrace
 
-
 PERIOD_DATE=$(date -u -d@"$(( `date -u +%s`-86400))" "+%Y-%m-%d")
-START_OF_PERIOD=$(date -d@"$(( `date -u +%s`-86400))" "+%Y-%m-%d 00:00:00")
-END_OF_PERIOD=$(date -u "+%Y-%m-%d 00:00:00")
 
+if [ -z "$START_DATE" ]; then
+  START_OF_PERIOD=$(date -d@"$(( `date -u +%s`-86400))" "+%Y-%m-%d 00:00:00")
+else
+  START_OF_PERIOD="$START_DATE 00:00:00"
+  PERIOD_DATE="${START_DATE}_initial_export"
+fi
+
+if [ -z "$END_DATE" ]; then
+  END_OF_PERIOD=$(date -u "+%Y-%m-%d 00:00:00")
+else
+  END_OF_PERIOD="$END_DATE 00:00:00"
+fi
 
 ############################################################################
 # PREPARE POSTGRES CERTIFICATES
@@ -207,6 +216,8 @@ EOF
   rm $filename
   rm "$filename".manifest
 fi
+
+echo "file export complete"
 
 # cleanup file
 rm $EVENTS_FILE

--- a/docker/run.sh
+++ b/docker/run.sh
@@ -20,7 +20,7 @@ fi
 if [ -z "$END_DATE" ]; then
   END_OF_PERIOD=$(date -u "+%Y-%m-%d 00:00:00")
 else
-  END_OF_PERIOD="$END_DATE 00:00:00"
+  END_OF_PERIOD="$END_DATE 23:59:59.9999"
 fi
 
 ############################################################################


### PR DESCRIPTION
### Why?
For the initial export of data to DAP and MI, its gonna be a big one! We need to be able to provide a start and end date to export the data already inserted into the database
### What?
Script checks for start and end date variables and uses these if present to select the data. These should only be present when running manually using the runbook. Also added an echo at the end to state when the export has finished.
### How?
Test manually by following the run book attached to the trello ticket. Also need to use the kubernetes repo checked out on the branch with the same name.
### Links?
https://trello.com/c/Ml32xpgI/1714-runbook-and-script-modify-mi-dap-one-off-initial-export-8