### PR TITLE
Fix broken cron: start date is never set on cron job

### DIFF
--- a/docker/run.sh
+++ b/docker/run.sh
@@ -4,7 +4,7 @@ echo "running rm-dataexporter job $(date)"
 # exit on errors, including unset variables (nounset)
 set -o errexit  
 set -o pipefail
-set -o nounset
+# set -o nounset
 # uncomment for trace
 # set -o xtrace
 


### PR DESCRIPTION
Looks like we (myself included) never tested this as an overnight cron job... it'll always fail because we don't pass in the start date, and bash is set up to always fail for any unset env var.