### PR TITLE
1575 - Allow start/end time for dataexport

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ The data is exported in JSON format, zipped up and stored in a GCS bucket where 
 The container is intended to be run within Kubernetes either as a cronjob (which will be run for the previous day as default), or with a start/end datetime.
 To run with a start/end datetime, connect to the one-off dataexport pod with bash, then run the job as follows:
 ```
-START_DATETIME=<YYYY-MM-DDTHH:MM:SS> END_DATETIME=<YYYY-MM-DD:HH:MM:SS> ./run.sh
+START_DATETIME=<YYYY-MM-DDTHH:MM:SS> END_DATETIME=<YYYY-MM-DDTHH:MM:SS> ./run.sh
 ```
 
 For example:
@@ -33,7 +33,6 @@ Ensure you are whitelisted against the test environment database.
 Use *./runlocaltest.sh*
 
 This will set the docker-compose environment variables based on the configmaps and secrets contained within the rm cluster you are connected to. *you must be whitelisted against the database for this to work*
-
 
 
 

--- a/README.md
+++ b/README.md
@@ -1,9 +1,18 @@
 # census-rm-data-exporter
-The Data Exporter is a scheduled batch job that runs once a day and exports a full set of case, event and qid information from the case database. 
+The Data Exporter is a scheduled batch job that runs once a day via a crontab job, or for a given start & end datetime. The data exporter exports a full set of case, event and qid information from the case database. 
 The data is exported in JSON format, zipped up and stored in a GCS bucket where it will be collected and sent downstream by MiNiFi.
 
 ## Running locally
-The container is intended to be run within Kubernetes as a cronjob (see census-rm-kubernetes/optional folder)
+The container is intended to be run within Kubernetes either as a cronjob (which will be run for the previous day as default), or with a start/end datetime.
+To run with a start/end datetime, connect to the one-off dataexport pod with bash, then run the job as follows:
+```
+START_DATETIME=<YYYY-MM-DDTHH:MM:SS> END_DATETIME=<YYYY-MM-DD:HH:MM:SS> ./run.sh
+```
+
+For example:
+```
+START_DATETIME=2020-12-01T00:00:00 END_DATETIME=2020-12-03T23:59:59.999999 ./run.sh
+```
 
 ### connect to an RM test kubernetes cluster
 To test changes locally *connect to an existing RM test cluster* configured to support the dataexporter.


### PR DESCRIPTION
# Motivation and Context
We need to allow dataexports of data between a given start/end timeframe. We also need to ensure we default the start/end timeframes if none are provided.

# What has changed
* Allow a start/end datetime. Default to yesterday's data if not provided.
* If running with a start/end datetime, the files will no longer have `_initial_export` hardcoded in the file names. 

# How to test?
* Build docker image off this branch and deploy the one-off dataexporter to your cluster
* Bash into the one-off pod
* Follow the README instructions (you'll need data in your database first, so just run the Acceptance Tests if needed)

# Links
https://trello.com/c/CitxVFzK/1575-make-data-exporter-runnable-over-a-configurable-period-5